### PR TITLE
Allow no srcs for directory rules.

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -1,6 +1,6 @@
 {
   "lockFileVersion": 6,
-  "moduleFileHash": "a45e2bc2ef8871832768746e4ff4eb354a3a3dfda2585641def9d13a5df99e90",
+  "moduleFileHash": "cfe0147f6871edd0ac4b9785ff9e24c7e78703920ffe36fbe76f69b7e46dd3b3",
   "flags": {
     "cmdRegistries": [
       "https://bcr.bazel.build/"
@@ -18,7 +18,7 @@
   "moduleDepGraph": {
     "<root>": {
       "name": "rules_directory",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "key": "<root>",
       "repoName": "rules_directory",
       "executionPlatformsToRegister": [],

--- a/directory/tests/BUILD.bazel
+++ b/directory/tests/BUILD.bazel
@@ -2,6 +2,8 @@ load("@rules_testing//lib:analysis_test.bzl", "analysis_test")
 load(
     ":directory_test.bzl",
     "directory_test",
+    "directory_with_no_srcs_test",
+    "directory_with_self_srcs_test",
     "outside_testdata_test",
 )
 load(
@@ -30,6 +32,23 @@ analysis_test(
         "f2": "//directory/tests/testdata:f2_filegroup",
         "f3": "//directory/tests/testdata:f3",
     },
+)
+
+analysis_test(
+    name = "directory_with_no_srcs_test",
+    impl = directory_with_no_srcs_test,
+    targets = {
+        "dir": "//directory/tests/testdata:dir_with_no_srcs",
+        "f1": "//directory/tests/testdata:f1_filegroup",
+        "f3": "//directory/tests/testdata:f3",
+    },
+)
+
+analysis_test(
+    name = "directory_with_self_srcs_test",
+    expect_failure = True,
+    impl = directory_with_self_srcs_test,
+    target = "//directory/tests/testdata:dir_with_self_srcs",
 )
 
 filegroup(

--- a/directory/tests/directory_test.bzl
+++ b/directory/tests/directory_test.bzl
@@ -64,3 +64,20 @@ def directory_test(env, targets):
     env.expect.that_str(directory_path(newdir.actual)).equals(
         newdir.actual.generated_path,
     )
+
+# buildifier: disable=function-docstring
+def directory_with_no_srcs_test(env, targets):
+    f1 = targets.f1.files.to_list()[0]
+    f3 = targets.f3.files.to_list()[0]
+
+    env.expect.that_collection(targets.dir.files.to_list()).contains_exactly([])
+
+    d = directory_subject(env, targets.dir[DirectoryInfo])
+    d.entries().contains_exactly({})
+    env.expect.that_str(d.actual.source_path + "/f1").equals(f1.path)
+    env.expect.that_str(d.actual.generated_path + "/newdir/f3").equals(f3.path)
+
+# buildifier: disable=function-docstring
+directory_with_self_srcs_test = failure_matching(matching.contains(
+    "directory/tests/testdata is not contained within @@//directory/tests/testdata",
+))

--- a/directory/tests/testdata/BUILD.bazel
+++ b/directory/tests/testdata/BUILD.bazel
@@ -21,6 +21,16 @@ directory(
     ) + [":f3"],
 )
 
+directory(
+    name = "dir_with_no_srcs",
+)
+
+util.helper_target(
+    directory,
+    name = "dir_with_self_srcs",
+    srcs = ["."],
+)
+
 util.helper_target(
     directory,
     name = "outside_testdata",

--- a/docs/directory.md
+++ b/docs/directory.md
@@ -7,7 +7,7 @@ Skylib module containing rules to create metadata about directories.
 ## directory
 
 <pre>
-directory(<a href="#directory-name">name</a>, <a href="#directory-srcs">srcs</a>)
+directory(<a href="#directory-name">name</a>, <a href="#directory-srcs">srcs</a>, <a href="#directory-kwargs">kwargs</a>)
 </pre>
 
 A marker for a bazel directory and its contents.
@@ -22,12 +22,13 @@ directory(
 )
 
 
-**ATTRIBUTES**
+**PARAMETERS**
 
 
-| Name  | Description | Type | Mandatory | Default |
-| :------------- | :------------- | :------------- | :------------- | :------------- |
-| <a id="directory-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
-| <a id="directory-srcs"></a>srcs |  The files contained within this directory and subdirectories.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | required |  |
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="directory-name"></a>name |  (str) The name of the label.   |  none |
+| <a id="directory-srcs"></a>srcs |  (List[Label|File]) The files contained within this directory and subdirectories.",   |  <code>[]</code> |
+| <a id="directory-kwargs"></a>kwargs |  Kwargs to be passed to the underlying rule.   |  none |
 
 


### PR DESCRIPTION
When no srcs are given, it is special-cased to fill both source_path and generated_path (previously it would fill neither).

Also rework source path calculation to ensure that the path is always correct, and add some test cases.